### PR TITLE
Shorten experience tab employer labels

### DIFF
--- a/content/jobs/ARG/index.md
+++ b/content/jobs/ARG/index.md
@@ -1,7 +1,8 @@
 ---
 date: '2018-02-01'
 title: 'Research Assistant'
-company: 'Morgan State University · Johns Hopkins University · U.S. Army DEVCOM Army Research Laboratory'
+company: 'Morgan State University · Johns Hopkins · U.S. Army DEVCOM'
+companyShort: 'Army Research Lab'
 location: 'Baltimore, MD'
 range: 'Feb 2018 - Dec 2020'
 url: ''

--- a/content/jobs/DEPA/index.md
+++ b/content/jobs/DEPA/index.md
@@ -2,6 +2,7 @@
 date: '2020-05-01'
 title: 'DevOps Engineer'
 company: 'Data Engineering and Predictive Analytics Laboratory'
+companyShort: 'DEPA Lab'
 location: 'Baltimore, MD'
 range: 'May 2020 - May 2021'
 url: ''

--- a/content/jobs/Microsoft-II/index.md
+++ b/content/jobs/Microsoft-II/index.md
@@ -1,7 +1,8 @@
 ---
 date: '2021-06-01'
 title: 'Software Engineer II'
-company: 'Microsoft Corporation'
+company: 'Microsoft'
+companyShort: 'Microsoft'
 location: 'Redmond, WA'
 range: 'June 2021 - Present'
 ---

--- a/src/components/sections/jobs.js
+++ b/src/components/sections/jobs.js
@@ -200,7 +200,7 @@ const Jobs = ({ data }) => {
         <StyledTabList role="tablist" aria-label="Job tabs" onKeyDown={e => onKeyPressed(e)}>
           {data &&
             data.map(({ node }, i) => {
-              const { company } = node.frontmatter;
+              const { company, companyShort } = node.frontmatter;
               return (
                 <li key={i}>
                   <StyledTabButton
@@ -212,7 +212,7 @@ const Jobs = ({ data }) => {
                     aria-selected={activeTabId === i ? true : false}
                     aria-controls={`panel-${i}`}
                     tabIndex={activeTabId === i ? '0' : '-1'}>
-                    <span>{company}</span>
+                    <span>{companyShort || company}</span>
                   </StyledTabButton>
                 </li>
               );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -71,6 +71,7 @@ export const pageQuery = graphql`
           frontmatter {
             title
             company
+            companyShort
             location
             range
             url


### PR DESCRIPTION
## Summary
- Adds an optional `companyShort` field for job entries.
- Shows concise employer names in the "Where I've Worked" tab list.
- Keeps fuller employer names in the job detail header.

## Test plan
- [x] `yarn build`
- [ ] Verify experience tabs show Microsoft, DEPA Lab, and Army Research Lab
- [ ] Verify expanded job details still show full employer names