### PR TITLE
Fix Mingla featured project URL

### DIFF
--- a/content/featured/mingla/index.md
+++ b/content/featured/mingla/index.md
@@ -3,7 +3,7 @@ date: '2026-08-01'
 title: 'Mingla'
 cover: './cover.png'
 github: 'https://github.com/Mingla-LLC/mingla-main'
-external: 'https://mingla.io/'
+external: 'https://usemingla.com/'
 tech:
   - TypeScript
   - React Native


### PR DESCRIPTION
Updates the Mingla featured project external link from `https://mingla.io/` to `https://usemingla.com/`.